### PR TITLE
Allow optional custom "r(adius)" property when drawing points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # go-geojson-svg
 
 Work in progress. This is a hard fork of Fabian Prein's [geojson2svg](https://godoc.org/github.com/fapian/geojson2svg).
+
+## Changes
+
+* When drawing points you _must_ pass a `r` attribute. Previously it was hardcoded to "1".

--- a/README.md
+++ b/README.md
@@ -2,6 +2,3 @@
 
 Work in progress. This is a hard fork of Fabian Prein's [geojson2svg](https://godoc.org/github.com/fapian/geojson2svg).
 
-## Changes
-
-* When drawing points you _must_ pass a `r` attribute. Previously it was hardcoded to "1".

--- a/svg.go
+++ b/svg.go
@@ -12,7 +12,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-
+	
 	geojson "github.com/paulmach/go.geojson"
 	"github.com/paulmach/orb"
 	"github.com/paulmach/orb/project"
@@ -260,7 +260,8 @@ func collect(g *geojson.Geometry) (ps [][]float64) {
 
 func drawPoint(sf scaleFunc, w io.Writer, p []float64, attributes string) {
 	x, y := sf(p[0], p[1])
-	fmt.Fprintf(w, `<circle cx="%f" cy="%f" r="1"%s/>`, x, y, attributes)
+	// fmt.Fprintf(w, `<circle cx="%f" cy="%f" r="1"%s/>`, x, y, attributes)
+	fmt.Fprintf(w, `<circle cx="%f" cy="%f" %s/>`, x, y, attributes)	
 }
 
 func drawMultiPoint(sf scaleFunc, w io.Writer, ps [][]float64, attributes string) {

--- a/svg.go
+++ b/svg.go
@@ -18,6 +18,8 @@ import (
 	"github.com/paulmach/orb/project"
 )
 
+var re_has_r = regexp.MustCompile(`r="\d+"`)
+
 // TODO release
 
 type scaleFunc func(float64, float64) (float64, float64)
@@ -260,8 +262,13 @@ func collect(g *geojson.Geometry) (ps [][]float64) {
 
 func drawPoint(sf scaleFunc, w io.Writer, p []float64, attributes string) {
 	x, y := sf(p[0], p[1])
-	// fmt.Fprintf(w, `<circle cx="%f" cy="%f" r="1"%s/>`, x, y, attributes)
-	fmt.Fprintf(w, `<circle cx="%f" cy="%f" %s/>`, x, y, attributes)	
+
+	if !re_has_r.MatchString(attributes){
+		fmt.Fprintf(w, `<circle cx="%f" cy="%f" r="1"%s/>`, x, y, attributes)
+		return
+	}
+	
+	fmt.Fprintf(w, `<circle cx="%f" cy="%f"%s/>`, x, y, attributes)	
 }
 
 func drawMultiPoint(sf scaleFunc, w io.Writer, ps [][]float64, attributes string) {


### PR DESCRIPTION
Previously this was hard-coded to always be "1".